### PR TITLE
GH-8 Skip git hooks during dzil release

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -48,6 +48,7 @@ format = ## %v%T - %{yyyy-MM-dd}d
 
 [Git::Commit]
 changelog = Changes.md
+commit_msg = Release %V
 [Git::Tag]
 [Git::Push]
 

--- a/utils/commit-msg-hook
+++ b/utils/commit-msg-hook
@@ -148,7 +148,7 @@ sub process_msg ($msg) {
 
 sub main {
   my ($file) = @ARGV;
-  # say STDERR "commit-msg hook: [$file]";
+  return 0 if $ENV{DZIL_RELEASING};
 
   open my $fh, "<", $file or die "Can't open $file: $!";
   my @msg = <$fh>;

--- a/utils/prepare-commit-msg-hook
+++ b/utils/prepare-commit-msg-hook
@@ -26,6 +26,7 @@ sub main {
   my ($file, $type) = @ARGV;
   $type //= "";
 
+  return 0 if $ENV{DZIL_RELEASING};
   return 0 if $type !~ /^(?:|message|template|merge)$/;
 
   my $ticket = get_ticket();


### PR DESCRIPTION
## Summary

During `dzil release`, the commit-msg hook rejects the release
commit message and blocks on a TTY prompt. Fix by checking
`$ENV{DZIL_RELEASING}` (set by dzil itself) in both hooks.

## Changes

- Skip validation in `commit-msg` and `prepare-commit-msg` hooks
  when `DZIL_RELEASING` is set.
- Set `commit_msg = Release %V` in `[Git::Commit]` so the release
  commit reads `Release v0.2.0` rather than just `v0.2.0`.

## Issue

Closes #8