### PR TITLE
GH-12 Close release ticket when PR is merged

### DIFF
--- a/utils/run
+++ b/utils/run
@@ -277,6 +277,7 @@ release_ticket() {
 
   # Step 5: Push branch and create PR
   confirm "push branch and create PR"
+  local pr_body="${body}"$'\n\n'"Closes #${issue_num}"
   if ((dryrun)); then
     release_pr_url="https://github.com/.../pull/NNN"
     pi "[dry run] would push $release_branch and create PR"
@@ -285,7 +286,7 @@ release_ticket() {
     release_pr_url=$(
       gh pr create \
         --title "$title" \
-        --body "$body" \
+        --body "$pr_body" \
         --base main
     )
     pi "Created PR: $release_pr_url"


### PR DESCRIPTION
## Summary

The release workflow creates a GitHub ticket and PR, but merging
the PR did not automatically close the ticket because the PR body
lacked a `Closes #N` keyword.

## Changes

- Append `Closes #N` to the release PR body so GitHub auto-closes
  the corresponding ticket on merge

## Implications

- No change to ticket body itself — only the PR body gets the
  closing keyword
- Dryrun mode uses the placeholder issue number as before

## Issue

Closes #12