### PR TITLE
GH-24 Update release skill documentation

### DIFF
--- a/.claude/skills/release/skill.md
+++ b/.claude/skills/release/skill.md
@@ -8,6 +8,14 @@ user_invocable: true
 
 # Release workflow for Perl-Critic-PJCJ
 
+## IMPORTANT — interactive commands
+
+`make release` and `utils/run release-ticket` are **interactive**
+scripts with multiple confirmation prompts. **Do not run them
+yourself.** Instead, tell the user which command to run and explain
+the preconditions. The user must run the command in their own
+terminal.
+
 ## Commands
 
 - **`make release`** — full release: creates a GitHub ticket,
@@ -19,5 +27,12 @@ user_invocable: true
 Both support `--dryrun` and must be run from `main` with a clean
 working tree (excluding `Changes.md`, which should be uncommitted).
 `release` also requires entries under `{{$NEXT}}` in `Changes.md`.
+
+## What you should do
+
+1. Verify the preconditions (correct branch, clean tree, changelog
+   entries, tests and lint passing).
+2. Tell the user which command to run (e.g. `make release`).
+3. Do **not** execute the command on their behalf.
 
 See `docs/release.md` for the full developer guide.


### PR DESCRIPTION
## Summary

Add documentation to the release skill clarifying that release commands are interactive and must be run by the user directly, not by Claude.

## Changes

- Add warning section about interactive commands with confirmation prompts.
- Add precondition checklist (correct branch, clean tree, changelog entries, tests and lint passing).

## Issue

Closes #24