### PR TITLE
GH-26 Add keyword-group-blanks-before option

### DIFF
--- a/.perltidyrc
+++ b/.perltidyrc
@@ -64,3 +64,4 @@
 --keep-old-blank-lines=1               # keep existing blank lines
 --keyword-group-blanks                 # add blank lines between keyword groups
 --keyword-group-blanks-size=5          # size of keyword groups
+--keyword-group-blanks-before=1        # not at the start of a block


### PR DESCRIPTION
## Summary

Add the `--keyword-group-blanks-before=1` option to `.perltidyrc` to prevent perltidy from inserting blank lines at the start of a block when grouping keywords.

## Changes

- Add `--keyword-group-blanks-before=1` to `.perltidyrc`.

## Issue

Closes #26