### PR TITLE
GH-28 Apply perltidy formatting

### DIFF
--- a/lib/Perl/Critic/Policy/ValuesAndExpressions/RequireConsistentQuoting.pm
+++ b/lib/Perl/Critic/Policy/ValuesAndExpressions/RequireConsistentQuoting.pm
@@ -21,15 +21,14 @@ sub supported_parameters { }
 sub default_severity     { $SEVERITY_MEDIUM }
 sub default_themes       { qw( cosmetic ) }
 
-sub applies_to { qw(
-  PPI::Token::Quote::Single
-  PPI::Token::Quote::Double
-  PPI::Token::Quote::Literal
-  PPI::Token::Quote::Interpolate
-  PPI::Token::QuoteLike::Words
-  PPI::Token::QuoteLike::Command
-  PPI::Statement::Include
-) }
+sub applies_to {
+  qw(
+    PPI::Token::Quote::Single    PPI::Token::Quote::Double
+    PPI::Token::Quote::Literal   PPI::Token::Quote::Interpolate
+    PPI::Token::QuoteLike::Words PPI::Token::QuoteLike::Command
+    PPI::Statement::Include
+  )
+}
 
 sub would_interpolate ($self, $string) {
   # This is the authoritative way to check - let PPI decide
@@ -163,9 +162,9 @@ sub check_delimiter_optimisation ($self, $elem) {
   $operator //= "q" if $start eq "'";
   my ($optimal_delim, $current_is_optimal)
     = $self->find_optimal_delimiter($content, $operator, $start, $end);
-  return $self->violation($Desc,
-    sprintf($Expl_optimal, $optimal_delim->{display}), $elem)
-    unless $current_is_optimal;
+  return $self->violation(
+    $Desc, sprintf($Expl_optimal, $optimal_delim->{display}), $elem
+  ) unless $current_is_optimal;
 
   undef
 }
@@ -233,8 +232,9 @@ sub check_double_quoted ($self, $elem) {
   # so qq() eliminates the quote escaping while preserving both
   if ($content =~ /\\"/) {
     my ($optimal) = $self->find_optimal_delimiter($string, "qq", '"', '"');
-    return $self->violation($Desc, sprintf($Expl_optimal, $optimal->{display}),
-      $elem);
+    return $self->violation(
+      $Desc, sprintf($Expl_optimal, $optimal->{display}), $elem
+    );
   }
 
   return
@@ -317,13 +317,13 @@ sub check_quote_operators ($self, $elem) {
   return unless defined $current_start;
 
   # Don't skip empty content - () is preferred even for empty quotes
-  my ($optimal_delim, $current_is_optimal)
-    = $self->find_optimal_delimiter($content, $operator, $current_start,
-      $current_end);
+  my ($optimal_delim, $current_is_optimal) = $self->find_optimal_delimiter(
+    $content, $operator, $current_start, $current_end
+  );
 
-  return $self->violation($Desc,
-    sprintf($Expl_optimal, $optimal_delim->{display}), $elem)
-    if !$current_is_optimal;
+  return $self->violation(
+    $Desc, sprintf($Expl_optimal, $optimal_delim->{display}), $elem
+  ) if !$current_is_optimal;
 
   return
 }
@@ -488,15 +488,17 @@ sub _summarise_use_arguments ($self, @args) {
   my $qw_uses_parens = 1;
 
   for my $arg (@args) {
-    $self->_count_use_arguments($arg, \$string_count, \$has_qw,
-      \$qw_uses_parens);
+    $self->_count_use_arguments(
+      $arg, \$string_count, \$has_qw, \$qw_uses_parens
+    );
   }
 
   ($string_count, $has_qw, $qw_uses_parens)
 }
 
-sub _count_use_arguments ($self, $elem, $str_count_ref, $qw_ref, $qw_parens_ref)
-{
+sub _count_use_arguments (
+  $self, $elem, $str_count_ref, $qw_ref, $qw_parens_ref
+) {
 
   $$str_count_ref++
     if $elem->isa("PPI::Token::Quote::Single")
@@ -513,8 +515,9 @@ sub _count_use_arguments ($self, $elem, $str_count_ref, $qw_ref, $qw_parens_ref)
   # Recursively check children (for structures like lists)
   if ($elem->can("children")) {
     for my $child ($elem->children) {
-      $self->_count_use_arguments($child, $str_count_ref, $qw_ref,
-        $qw_parens_ref);
+      $self->_count_use_arguments(
+        $child, $str_count_ref, $qw_ref, $qw_parens_ref
+      );
     }
   }
 }
@@ -527,9 +530,10 @@ sub _is_pragma ($self, $elem) {
 sub _is_in_use_statement ($self, $elem) {
   my $current = $elem;
   while ($current) {
-    if ($current->isa("PPI::Statement::Include")
-      && ($current->type =~ /^(use|no)$/))
-    {
+    if (
+      $current->isa("PPI::Statement::Include")
+      && ($current->type =~ /^(use|no)$/)
+    ) {
       my @args = $self->_extract_use_arguments($current);
 
       # Single-arg pragmas follow normal quoting rules

--- a/t/CodeLayout/ProhibitLongLines/line_number_reporting.t
+++ b/t/CodeLayout/ProhibitLongLines/line_number_reporting.t
@@ -48,8 +48,9 @@ Another short line
 my $other = 2;
 EOCODE
 
-  my @violations = line_numbers($code_with_pod, [8],
-    "POD long line should report correct line number");
+  my @violations = line_numbers(
+    $code_with_pod, [8], "POD long line should report correct line number"
+  );
 
   # Also check the exact message
   is $violations[0]->description, "Line is 73 characters long (exceeds 72)",
@@ -146,8 +147,10 @@ my $var = 1;
 my $other = 2;
 EOCODE
 
-  my @violations = line_numbers($comment_code, [2],
-    "Comment long lines should report correct line numbers");
+  my @violations = line_numbers(
+    $comment_code, [2],
+    "Comment long lines should report correct line numbers"
+  );
 
   is $violations[0]->description, "Line is 73 characters long (exceeds 72)",
     "Comment violation has correct message";
@@ -164,8 +167,10 @@ my $var = 1;
 my $very_long_variable_name_that_exceeds_seventy_two_char_limit_after_pod = "v";
 EOCODE
 
-  my @violations = line_numbers($empty_pod_code, [7],
-    "Code after empty POD should report correct line numbers");
+  my @violations = line_numbers(
+    $empty_pod_code, [7],
+    "Code after empty POD should report correct line numbers"
+  );
 
   is $violations[0]->description, "Line is 80 characters long (exceeds 72)",
     "Line after empty POD has correct violation message";


### PR DESCRIPTION
## Summary

Reformat source files with the new `--keyword-group-blanks-before=1` perltidy option added in GH-26.

## Changes

- Reformat `RequireConsistentQuoting.pm` and `line_number_reporting.t`.
- No functional changes.

## Issue

Closes #28