### PR TITLE
GH-30 Fix false backslash match

### DIFF
--- a/lib/Perl/Critic/Policy/ValuesAndExpressions/RequireConsistentQuoting.pm
+++ b/lib/Perl/Critic/Policy/ValuesAndExpressions/RequireConsistentQuoting.pm
@@ -220,17 +220,22 @@ sub check_double_quoted ($self, $elem) {
   # Special case: strings with newlines don't follow the rules
   return if $self->_has_newlines($string);
 
+  # Strip delimiters and remove \\ pairs so escaped backslashes before the
+  # closing delimiter aren't mistaken for escaped specials
+  my $inner = substr $content, 1, -1;
+  (my $cleaned = $inner) =~ s/\\\\//g;
+
   # Check for escaped dollar/at signs or double quotes, but only suggest single
   # quotes if no other interpolation exists AND no dangerous escape sequences
   return $self->violation($Desc, $Expl_single, $elem)
-    if $content =~ /\\[\$\@\"]/
+    if $cleaned =~ /\\[\$\@\"]/
     && !$self->_has_quote_sensitive_escapes($string)
     && !$self->would_interpolate($string);
 
   # If has escaped double quotes, suggest qq() — by this point, the ''
   # suggestion was ruled out (escape sequences or interpolation present),
   # so qq() eliminates the quote escaping while preserving both
-  if ($content =~ /\\"/) {
+  if ($cleaned =~ /\\"/) {
     my ($optimal) = $self->find_optimal_delimiter($string, "qq", '"', '"');
     return $self->violation(
       $Desc, sprintf($Expl_optimal, $optimal->{display}), $elem


### PR DESCRIPTION
## Summary

Fix a bug where `check_double_quoted` incorrectly suggested `use ''` for strings like `"\\"`. The regex `/\\[\$\@\"]/` on raw content confused escaped backslashes before the closing delimiter with escaped special characters, creating a circular contradiction: `"\\"` suggested `use ''` while `'\\'` suggested `use ""`.

## Changes

- Strip quote delimiters and remove `\\` pairs before checking for escaped specials (`\$`, `\@`, `\"`), so that `\\` + closing `"` is no longer misidentified as `\"`.

## Implications

- Tests for this fix follow in the next PR (GH-31). One test currently fails as expected.

## Issue

Closes #30