### PR TITLE
GH-38 Suggest '' for qq/q with embedded "

### DIFF
--- a/lib/Perl/Critic/Policy/ValuesAndExpressions/RequireConsistentQuoting.pm
+++ b/lib/Perl/Critic/Policy/ValuesAndExpressions/RequireConsistentQuoting.pm
@@ -41,7 +41,9 @@ sub would_interpolate ($self, $string) {
   state %cache;
   return $cache{$string} if exists $cache{$string};
 
-  my $test_content = qq("$string");
+  # Neutralise embedded double quotes so wrapping in "..." is valid PPI
+  my $safe         = $string =~ s/"/ /gr;
+  my $test_content = qq("$safe");
   my $test_doc     = PPI::Document->new(\$test_content);
 
   my $would_interpolate = 0;
@@ -256,11 +258,9 @@ sub check_q_literal ($self, $elem) {
       : $self->violation($Desc, $Expl_double, $elem);
   }
 
-  if ($has_double_quotes) {
-    return $would_interpolate
-      ? $self->check_delimiter_optimisation($elem)
-      : $self->violation($Desc, $Expl_single, $elem);
-  }
+  # Only double quotes (no single quotes) - single quotes always work:
+  # they don't interpolate and can hold " without escaping
+  return $self->violation($Desc, $Expl_single, $elem) if $has_double_quotes;
 
   return $self->violation($Desc, $Expl_single, $elem) if $would_interpolate;
 
@@ -284,8 +284,6 @@ sub check_qq_interpolate ($self, $elem) {
 
   # Rules 1,2: If double quotes would suggest single quotes, use single quotes
   if ($double_quote_suggestion && $double_quote_suggestion eq "''") {
-    # qq() is only justified if it handles double quotes cleanly
-    return if index($string, '"') != -1;
     return $self->violation($Desc, $Expl_single, $elem);
   }
 

--- a/t/ValuesAndExpressions/RequireConsistentQuoting/delimiter_optimisation.t
+++ b/t/ValuesAndExpressions/RequireConsistentQuoting/delimiter_optimisation.t
@@ -144,8 +144,8 @@ subtest "Equal bracket counts" => sub {
 subtest "Exotic delimiters" => sub {
   bad $Policy, 'my $text = qq/path\/to\/file/', 'use ""',
     "qq// with slashes should use double quotes";
-  good $Policy, 'my $text = qq(path"to"file)',
-    "qq() optimal when content has double quotes";
+  bad $Policy, 'my $text = qq(path"to"file)', "use ''",
+    "qq() with only double quotes should use single quotes";
   bad $Policy, 'my $text = q|option\|value|', 'use ""',
     "q|| with pipes should use double quotes";
   good $Policy, 'my $text = "option|value"',
@@ -216,17 +216,17 @@ subtest "q() delimiter optimisation path coverage" => sub {
   bad $Policy, q(my $text = q|can't use $var|), "use q()",
     "q| with single quotes and interpolation should use q()";
 
-  # Test: q() with double quotes and interpolation - justified,
-  # optimise delimiter
-  bad $Policy, q(my $text = q|Hello "there" $name|), "use q()",
-    "q| with double quotes and interpolation should use q()";
+  # Test: q() with double quotes and interpolation - single quotes handle both
+  bad $Policy, 'my $text = q|Hello "there" $name|', "use ''",
+    "q| with double quotes and interpolation should use single quotes";
 
   # Test: q() already using optimal delimiter should not violate
   good $Policy, q[my $text = q(mix 'single' and "double")],
     "q() with mixed quotes and optimal delimiter is justified";
 
-  good $Policy, q[my $text = q(Hello "there" $name)],
-    "q() with double quotes and interpolation is justified";
+  # q() with double quotes and interpolation should use single quotes
+  bad $Policy, 'my $text = q(Hello "there" $name)', "use ''",
+    "q() with double quotes and interpolation should use single quotes";
 };
 
 done_testing;

--- a/t/ValuesAndExpressions/RequireConsistentQuoting/quote_operators.t
+++ b/t/ValuesAndExpressions/RequireConsistentQuoting/quote_operators.t
@@ -114,9 +114,11 @@ subtest "qq() operator" => sub {
   bad $Policy, 'my $x = qq{simple[brackets]}', 'use ""',
     "qq{} with brackets should use double quotes";
 
-  # When qq() is appropriate (has double quotes)
-  good $Policy, 'my $x = qq(has "double" quotes)',
-    "qq() appropriate when content has double quotes";
+  # qq() with only double quotes should use single quotes
+  bad $Policy, 'my $x = qq(has "double" quotes)', "use ''",
+    "qq() with only double quotes should use single quotes";
+  bad $Policy, 'my $x = qq(<td class="%s">T</td>)', "use ''",
+    "qq() with HTML containing double quotes should use single quotes";
 
   # When qq() is justified due to special characters and optimal delimiter
   good $Policy, 'my $x = qq(string with $var and "quotes")',


### PR DESCRIPTION
## Summary

`qq()` and `q()` strings containing double quotes but no single quotes were not flagged, even when single quotes would be simpler. For example, `qq(<td class="%s">T</td>)` produced no violation despite `'<td class="%s">T</td>'` being the correct recommendation.

## Changes

- Fix `would_interpolate` to neutralise embedded double quotes before wrapping in `"..."` for PPI parsing. Previously, embedded `"` created invalid syntax causing PPI to miss interpolation.
- Remove guard in `check_qq_interpolate` that suppressed violations for any `qq()` with embedded double quotes, which was a workaround for the `would_interpolate` bug.
- Simplify `check_q_literal` to always suggest single quotes when content has only double quotes (no single quotes), since single quotes handle both the `"` and any sigils without escaping or interpolation.

## Implications

- Codebases using `qq()` or `q()` for strings with embedded double quotes but no interpolation or single quotes will see new violations recommending single quotes.

## Coverage

| Module | Statement | Branch | Condition | Subroutine |
|--------|-----------|--------|-----------|------------|
| RequireConsistentQuoting.pm | 99.7% | 96.3% | 89.1% | 100.0% |

## Issue

Closes #38