### PR TITLE
GH-40 Accept "y" at release prompts

### DIFF
--- a/utils/run
+++ b/utils/run
@@ -127,7 +127,7 @@ confirm() {
   pi "About to: $description"
   local answer
   read -rp "Continue? [yes/NO] " answer
-  if [[ ${answer,,} != "yes" ]]; then
+  if [[ ${answer,,} != "yes" && ${answer,,} != "y" ]]; then
     pf "Aborted"
   fi
 }
@@ -326,7 +326,7 @@ release() {
   else
     local answer
     read -rp "Continue after PR review? [yes/NO] " answer
-    if [[ ${answer,,} != "yes" ]]; then
+    if [[ ${answer,,} != "yes" && ${answer,,} != "y" ]]; then
       pf "Aborted"
     fi
   fi


### PR DESCRIPTION
## Summary

Both confirmation checkpoints in the release workflow require typing "yes" in full. Accept "y" as a shorthand for convenience, without changing the prompt text.

## Changes

- Both confirmation guards in `utils/run` (`confirm()` and the PR review pause) now accept "y" as well as "yes" (case-insensitive)

## Implications

- No functional change for existing "yes" responses
- Prompt text remains `[yes/NO]`

## Issue

Closes #40