### PR TITLE
GH-44 Count line length in characters

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -95,5 +95,5 @@ repos:
         name: Check for duplicated code
         description: Ensure we don't have large sections of duplicated code
         language: node
-        entry: jscpd --gitignore
+        entry: jscpd
         pass_filenames: true

--- a/Changes.md
+++ b/Changes.md
@@ -2,6 +2,12 @@
 
 {{$NEXT}}
 
+- Count ProhibitLongLines line length in characters, not octets
+  - Lines with multi-byte UTF-8 characters are no longer wrongly flagged as
+    too long
+  - Single-byte source (ASCII, Latin-1) is unaffected; other multi-byte
+    encodings are not decoded and still count by octets
+
 ## v0.2.6 - 2026-04-11
 
 - Suggest single quotes for qq/q strings containing only double quotes

--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ code density.
 You can configure `perltidy` to keep lines within the specified limit. Only
 when it is unable to do that will you need to manually make changes.
 
+Line lengths are measured in characters. Source is decoded as UTF-8 before
+measuring, so each multi-byte UTF-8 character counts as one. Single-byte
+encodings such as ASCII and Latin-1 are also measured correctly. Source in
+other multi-byte encodings (for example Shift-JIS) is not decoded and is
+measured by its octet length instead.
+
 #### Configuration
 
 - **max_line_length** - Maximum allowed line length in characters (default: 80)

--- a/lib/Perl/Critic/Policy/CodeLayout/ProhibitLongLines.pm
+++ b/lib/Perl/Critic/Policy/CodeLayout/ProhibitLongLines.pm
@@ -164,6 +164,14 @@ code density.
 You can configure C<perltidy> to keep lines within the specified limit.  Only
 when it is unable to do that will you need to manually make changes.
 
+=head1 CHARACTER ENCODING
+
+Line lengths are measured in characters.  Source is decoded as UTF-8 before
+measuring, so each multi-byte UTF-8 character counts as one.  Single-byte
+encodings such as ASCII and Latin-1 are also measured correctly.  Source in
+other multi-byte encodings (for example Shift-JIS) is not decoded and is
+measured by its octet length instead.
+
 =head1 CONFIGURATION
 
 =head2 max_line_length

--- a/lib/Perl/Critic/Policy/CodeLayout/ProhibitLongLines.pm
+++ b/lib/Perl/Critic/Policy/CodeLayout/ProhibitLongLines.pm
@@ -8,6 +8,7 @@ use experimental "signatures";
 
 use parent qw( Perl::Critic::Policy );
 
+use Encode                              qw( decode FB_CROAK );
 use File::Basename                      qw( dirname );
 use List::Util                          qw( any );
 use Perl::Critic::Utils                 qw( $SEVERITY_MEDIUM );
@@ -48,7 +49,13 @@ sub violates ($self, $elem, $doc) {
   my $max_length = $override // $self->{_max_line_length};
   my @patterns   = keys $self->{_allow_lines_matching}->%*;
   my $source     = $doc->serialize;
-  my @lines      = split /\n/, $source;
+
+  # PPI serializes source as octets, so decode to characters before measuring
+  # line lengths.  Keep the octets if the source is not valid UTF-8.
+  my $decoded = eval { decode("UTF-8", $source, FB_CROAK) };
+  $source = $decoded if defined $decoded;
+
+  my @lines = split /\n/, $source;
 
   my @violations;
 

--- a/t/CodeLayout/ProhibitLongLines/character_length.t
+++ b/t/CodeLayout/ProhibitLongLines/character_length.t
@@ -1,0 +1,99 @@
+#!/usr/bin/env perl
+
+use v5.26.0;
+use strict;
+use warnings;
+use utf8;
+
+use Test2::V0    qw( done_testing is subtest );
+use feature      qw( signatures );
+use experimental qw( signatures );
+
+use lib                                                 qw( lib t/lib );
+use Perl::Critic::Policy::CodeLayout::ProhibitLongLines ();
+use ViolationFinder                                     qw( bad good );
+use Encode                                              qw( encode );
+
+my $Policy = Perl::Critic::Policy::CodeLayout::ProhibitLongLines->new;
+
+# PPI reads source files as bytes, so a line with multi-byte UTF-8 characters
+# must be measured by its character count, not its octet count.  These tests
+# hand the policy a byte string, exactly as PPI does when reading from disk.
+
+subtest "Multi-byte characters are counted as characters not octets" => sub {
+  my $line = 'my $x = "' . ("\x{e9}" x 60) . '";';
+  is length($line), 71, "Line is 71 characters";
+
+  my $bytes = encode("UTF-8", $line);
+  is length($bytes), 131, "Line is 131 octets when UTF-8 encoded";
+
+  good $Policy, $bytes,
+    "Line of 71 characters does not violate the 80 character limit";
+};
+
+subtest "Character count is reported and long lines still detected" => sub {
+  my $line = 'my $x = "' . ("\x{e9}" x 90) . '";';
+  is length($line), 101, "Line is 101 characters";
+
+  my $bytes = encode("UTF-8", $line);
+  is length($bytes), 191, "Line is 191 octets when UTF-8 encoded";
+
+  bad $Policy, $bytes, "Line is 101 characters long (exceeds 80)",
+    "Multi-byte line over 80 characters violates with character count";
+};
+
+# Source files in a single-byte encoding (Latin-1, Windows-1252) are not valid
+# UTF-8, so the policy keeps the octets.  That still gives the correct count
+# because one octet is one character in these encodings.
+
+subtest "Latin-1 source is counted by characters" => sub {
+  my $line = 'my $x = "' . ("\x{e9}" x 60) . '";';
+  is length($line), 71, "Line is 71 characters";
+
+  my $bytes = encode("ISO-8859-1", $line);
+  is length($bytes), 71, "Line is 71 octets when Latin-1 encoded";
+
+  good $Policy, $bytes,
+    "Latin-1 line of 71 characters does not violate the 80 character limit";
+
+  my $long = 'my $x = "' . ("\x{e9}" x 90) . '";';
+  bad $Policy, encode("ISO-8859-1", $long),
+    "Line is 101 characters long (exceeds 80)",
+    "Latin-1 line over 80 characters violates with character count";
+};
+
+subtest "Windows-1252 source is counted by characters" => sub {
+  my $line = 'my $x = "' . ("\x{2019}" x 60) . '";';
+  is length($line), 71, "Line is 71 characters";
+
+  my $bytes = encode("cp1252", $line);
+  is length($bytes), 71, "Line is 71 octets when Windows-1252 encoded";
+
+  good $Policy, $bytes,
+    "Windows-1252 line of 71 characters does not violate the 80 limit";
+
+  my $long = 'my $x = "' . ("\x{2019}" x 90) . '";';
+  bad $Policy, encode("cp1252", $long),
+    "Line is 101 characters long (exceeds 80)",
+    "Windows-1252 line over 80 characters violates with character count";
+};
+
+# Known limitation: only UTF-8 is decoded.  A multi-byte source in any other
+# encoding (here Shift-JIS) is not valid UTF-8, so it falls back to octet
+# counting and over-counts.  This characterises that behaviour: a 47 character
+# line is reported as 83 because each Japanese character is two Shift-JIS
+# octets.  Perl source is conventionally UTF-8 or single-byte, so this is an
+# accepted trade-off rather than a bug to fix here.
+
+subtest "Non-UTF-8 multi-byte source falls back to octet counting" => sub {
+  my $line = 'my $x = "' . ("\x{3042}" x 36) . '";';
+  is length($line), 47, "Line is 47 characters";
+
+  my $bytes = encode("shiftjis", $line);
+  is length($bytes), 83, "Line is 83 octets when Shift-JIS encoded";
+
+  bad $Policy, $bytes, "Line is 83 characters long (exceeds 80)",
+    "Shift-JIS line is counted by octets, not characters";
+};
+
+done_testing;


### PR DESCRIPTION
## Summary

ProhibitLongLines measured lines in octets, so lines containing multi-byte UTF-8 characters were counted by their byte length and could be wrongly flagged as too long. It now decodes the source as UTF-8 and measures characters, matching the documented behaviour.

## Changes

- Decode source as UTF-8 before measuring line length, falling back to octet counting for source that is not valid UTF-8.
- Add tests covering UTF-8, Latin-1, Windows-1252 and Shift-JIS source, including a characterisation test for the octet fallback on non-UTF-8 multi-byte encodings.
- Document the character-counting behaviour and its UTF-8-only scope in the policy POD and the README.
- Update the jscpd pre-commit entry for the jscpd v5 release, which had begun failing on the removed `--gitignore` flag (incidental tooling fix carried on this branch).

## Implications

- Single-byte source (ASCII, Latin-1) is unaffected. Other multi-byte encodings (for example Shift-JIS) are still counted by octets, as documented.

## Issue

Closes #44